### PR TITLE
feat:자잘한 ui 수정

### DIFF
--- a/app/components/molecules/about/AboutCapabilitiesSection.tsx
+++ b/app/components/molecules/about/AboutCapabilitiesSection.tsx
@@ -35,6 +35,13 @@ export default function AboutCapabilitiesSection({
     triggerOnce: true,
   });
 
+  const capabilityBrief = skillCategories
+    .map((category) => ({
+      title: category.title,
+      description: category.description,
+    }))
+    .filter((item) => item.description && item.description.trim().length > 0);
+
   // 실제 높이 측정 및 부모에 전달
   useEffect(() => {
     if (!containerRef.current || !onHeightChange) return;
@@ -125,6 +132,20 @@ export default function AboutCapabilitiesSection({
         <h2 className="text-primary text-3xl font-bold tracking-[0.3em]">
           {title}
         </h2>
+        {capabilityBrief.length > 0 && (
+          <div className="mt-2 flex flex-col gap-1 border-l-2 border-primary/30 pl-3 text-[0.75rem] leading-relaxed text-[#a8b2d1]">
+            {capabilityBrief.map((item) => (
+              <p key={item.title} className="font-mono">
+                <span className="text-primary/90">{"> "}</span>
+                <span className="text-[#E6F1FF]">
+                  {item.title.toUpperCase()}
+                </span>
+                <span className="text-primary/60">{" :: "}</span>
+                <span>{item.description}</span>
+              </p>
+            ))}
+          </div>
+        )}
       </div>
       <div className="flex flex-col gap-6">
         {/* 핵심 코어 - 프레임워크 & 언어 */}

--- a/app/components/organisms/hero/HeroSection.tsx
+++ b/app/components/organisms/hero/HeroSection.tsx
@@ -11,7 +11,7 @@ import ScrollIndicatorLink from "@/app/components/molecules/hero/ScrollIndicator
 import AboutSystemHeader from "@/app/components/molecules/about/AboutSystemHeader";
 import { heroTexts } from "@/app/lib/i18n/texts";
 
-const TECH_PILLS = ["React", "Next.js", "TypeScript", "WebGL", "Three.js"];
+const TECH_PILLS = ["React", "Next.js", "TypeScript", "Node.js", "Flutter"];
 
 export default function HeroSection() {
   const { language } = useUI();

--- a/app/components/organisms/pdf/PDFIndexPage.tsx
+++ b/app/components/organisms/pdf/PDFIndexPage.tsx
@@ -10,6 +10,16 @@ interface PDFIndexPageProps {
 export default function PDFIndexPage({ projects }: PDFIndexPageProps) {
   return (
     <div className="pdf-layout min-h-screen bg-white text-gray-900">
+      {/* 홈으로 이동 */}
+      <div className="fixed top-4 right-4 print:hidden z-50">
+        <Link
+          href="/"
+          className="inline-flex items-center gap-2 rounded-full border border-gray-300 bg-white px-4 py-2 text-sm font-semibold text-gray-800 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+        >
+          홈으로
+        </Link>
+      </div>
+
       <div className="max-w-4xl mx-auto px-8 py-12 print:px-12 print:py-16">
         <header className="mb-12 print:mb-16 text-center border-b-2 border-gray-200 pb-8 print:pb-12">
           <h1 className="text-4xl print:text-5xl font-bold text-gray-900 mb-4 print:mb-6">
@@ -29,39 +39,63 @@ export default function PDFIndexPage({ projects }: PDFIndexPageProps) {
               </h2>
               <div className="space-y-6 print:space-y-8">
                 {projects.featured.map((project) => (
-                  <div
-                    key={project.id}
-                    className="border border-gray-200 rounded-lg p-6 print:p-8 hover:shadow-lg transition-shadow"
-                  >
-                    <div className="flex items-start justify-between mb-4 print:mb-6">
-                      <div>
-                        <h3 className="text-xl print:text-2xl font-bold text-gray-900 mb-2 print:mb-3">
-                          {project.title}
-                        </h3>
-                        <p className="text-base print:text-lg text-gray-600 leading-relaxed">
-                          {project.description}
-                        </p>
+                  project.slug ? (
+                    <Link
+                      key={project.id}
+                      href={`/pdf/${project.slug}`}
+                      className="group block border border-gray-200 rounded-lg p-6 print:p-8 hover:shadow-lg transition-shadow focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+                    >
+                      <div className="flex items-start justify-between mb-4 print:mb-6">
+                        <div>
+                          <h3 className="text-xl print:text-2xl font-bold text-gray-900 mb-2 print:mb-3">
+                            {project.title}
+                          </h3>
+                          <p className="text-base print:text-lg text-gray-600 leading-relaxed">
+                            {project.description}
+                          </p>
+                        </div>
+                      </div>
+                      <div className="flex flex-wrap gap-2 mb-4 print:mb-6">
+                        {project.tags.map((tag, index) => (
+                          <span
+                            key={index}
+                            className="px-3 py-1 text-sm print:text-base bg-gray-100 text-gray-700 rounded-md"
+                          >
+                            {tag}
+                          </span>
+                        ))}
+                      </div>
+                      <span className="inline-flex items-center gap-1 text-base print:text-lg text-blue-600 group-hover:text-blue-800 font-semibold print:hidden">
+                        View PDF <span aria-hidden>→</span>
+                      </span>
+                    </Link>
+                  ) : (
+                    <div
+                      key={project.id}
+                      className="border border-gray-200 rounded-lg p-6 print:p-8"
+                    >
+                      <div className="flex items-start justify-between mb-4 print:mb-6">
+                        <div>
+                          <h3 className="text-xl print:text-2xl font-bold text-gray-900 mb-2 print:mb-3">
+                            {project.title}
+                          </h3>
+                          <p className="text-base print:text-lg text-gray-600 leading-relaxed">
+                            {project.description}
+                          </p>
+                        </div>
+                      </div>
+                      <div className="flex flex-wrap gap-2 mb-4 print:mb-6">
+                        {project.tags.map((tag, index) => (
+                          <span
+                            key={index}
+                            className="px-3 py-1 text-sm print:text-base bg-gray-100 text-gray-700 rounded-md"
+                          >
+                            {tag}
+                          </span>
+                        ))}
                       </div>
                     </div>
-                    <div className="flex flex-wrap gap-2 mb-4 print:mb-6">
-                      {project.tags.map((tag, index) => (
-                        <span
-                          key={index}
-                          className="px-3 py-1 text-sm print:text-base bg-gray-100 text-gray-700 rounded-md"
-                        >
-                          {tag}
-                        </span>
-                      ))}
-                    </div>
-                    {project.slug && (
-                      <Link
-                        href={`/pdf/${project.slug}`}
-                        className="inline-block text-base print:text-lg text-blue-600 hover:text-blue-800 font-semibold print:hidden"
-                      >
-                        View PDF →
-                      </Link>
-                    )}
-                  </div>
+                  )
                 ))}
               </div>
             </section>
@@ -75,39 +109,63 @@ export default function PDFIndexPage({ projects }: PDFIndexPageProps) {
               </h2>
               <div className="space-y-6 print:space-y-8">
                 {projects.others.map((project) => (
-                  <div
-                    key={project.id}
-                    className="border border-gray-200 rounded-lg p-6 print:p-8 hover:shadow-lg transition-shadow"
-                  >
-                    <div className="flex items-start justify-between mb-4 print:mb-6">
-                      <div>
-                        <h3 className="text-xl print:text-2xl font-bold text-gray-900 mb-2 print:mb-3">
-                          {project.title}
-                        </h3>
-                        <p className="text-base print:text-lg text-gray-600 leading-relaxed">
-                          {project.description}
-                        </p>
+                  project.slug ? (
+                    <Link
+                      key={project.id}
+                      href={`/pdf/${project.slug}`}
+                      className="group block border border-gray-200 rounded-lg p-6 print:p-8 hover:shadow-lg transition-shadow focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+                    >
+                      <div className="flex items-start justify-between mb-4 print:mb-6">
+                        <div>
+                          <h3 className="text-xl print:text-2xl font-bold text-gray-900 mb-2 print:mb-3">
+                            {project.title}
+                          </h3>
+                          <p className="text-base print:text-lg text-gray-600 leading-relaxed">
+                            {project.description}
+                          </p>
+                        </div>
+                      </div>
+                      <div className="flex flex-wrap gap-2 mb-4 print:mb-6">
+                        {project.tags.map((tag, index) => (
+                          <span
+                            key={index}
+                            className="px-3 py-1 text-sm print:text-base bg-gray-100 text-gray-700 rounded-md"
+                          >
+                            {tag}
+                          </span>
+                        ))}
+                      </div>
+                      <span className="inline-flex items-center gap-1 text-base print:text-lg text-blue-600 group-hover:text-blue-800 font-semibold print:hidden">
+                        View PDF <span aria-hidden>→</span>
+                      </span>
+                    </Link>
+                  ) : (
+                    <div
+                      key={project.id}
+                      className="border border-gray-200 rounded-lg p-6 print:p-8"
+                    >
+                      <div className="flex items-start justify-between mb-4 print:mb-6">
+                        <div>
+                          <h3 className="text-xl print:text-2xl font-bold text-gray-900 mb-2 print:mb-3">
+                            {project.title}
+                          </h3>
+                          <p className="text-base print:text-lg text-gray-600 leading-relaxed">
+                            {project.description}
+                          </p>
+                        </div>
+                      </div>
+                      <div className="flex flex-wrap gap-2 mb-4 print:mb-6">
+                        {project.tags.map((tag, index) => (
+                          <span
+                            key={index}
+                            className="px-3 py-1 text-sm print:text-base bg-gray-100 text-gray-700 rounded-md"
+                          >
+                            {tag}
+                          </span>
+                        ))}
                       </div>
                     </div>
-                    <div className="flex flex-wrap gap-2 mb-4 print:mb-6">
-                      {project.tags.map((tag, index) => (
-                        <span
-                          key={index}
-                          className="px-3 py-1 text-sm print:text-base bg-gray-100 text-gray-700 rounded-md"
-                        >
-                          {tag}
-                        </span>
-                      ))}
-                    </div>
-                    {project.slug && (
-                      <Link
-                        href={`/pdf/${project.slug}`}
-                        className="inline-block text-base print:text-lg text-blue-600 hover:text-blue-800 font-semibold print:hidden"
-                      >
-                        View PDF →
-                      </Link>
-                    )}
-                  </div>
+                  )
                 ))}
               </div>
             </section>

--- a/app/components/organisms/pdf/ProjectPDFView.tsx
+++ b/app/components/organisms/pdf/ProjectPDFView.tsx
@@ -2,6 +2,7 @@
 import type { ProjectItem, ProjectDetail } from "@/app/types/projects";
 import ProjectPDFContent from "@/app/components/organisms/pdf/ProjectPDFContent";
 import "@/app/styles/pdf.css";
+import Link from "next/link";
 
 interface ProjectPDFViewProps {
   project: ProjectItem;
@@ -14,6 +15,16 @@ export default async function ProjectPDFView({
 }: ProjectPDFViewProps) {
   return (
     <div className="pdf-layout min-h-screen bg-white text-gray-900">
+      {/* 뒤로가기 */}
+      <div className="fixed top-4 right-4 print:hidden z-50 flex gap-2">
+        <Link
+          href="/pdf"
+          className="inline-flex items-center gap-2 rounded-full border border-gray-300 bg-white px-4 py-2 text-sm font-semibold text-gray-800 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+        >
+          ← 목록으로
+        </Link>
+      </div>
+
       {/* PDF 인쇄 안내 (화면에서만 표시) */}
       <div className="fixed bottom-4 right-4 bg-blue-600 text-white px-6 py-4 rounded-lg shadow-lg print:hidden z-50">
         <p className="text-sm font-semibold mb-2">PDF로 저장하기</p>

--- a/app/lib/api/about.ts
+++ b/app/lib/api/about.ts
@@ -234,7 +234,7 @@ const skillCopy: Record<
     frontend: "웹 · 모바일 프런트엔드 전반을 다루며 UI/UX 품질을 끌어올립니다.",
     backend: "다양한 백엔드 프레임워크로 비즈니스 로직과 API를 설계합니다.",
     infra: "배포 자동화와 서비스 운영 환경을 안정적으로 구성합니다.",
-    database: "관계형/비관계형 DB와 클라우드 백엔드를 활용합니다.",
+    database: "관계형/비관계형 DB와 클라우드 서비스를 활용합니다.",
     ai: "AI 기반 서비스와 데이터 파이프라인을 프로덕트에 접목합니다.",
   },
   en: {
@@ -244,7 +244,7 @@ const skillCopy: Record<
     infra:
       "Building reliable deployment automation and operations environments.",
     database:
-      "Leveraging relational, non-relational databases and cloud backends.",
+      "Leveraging relational, non-relational databases and cloud services.",
     ai: "Integrating AI services and data pipelines into products.",
   },
 };
@@ -282,7 +282,7 @@ function buildSkillCategories(language: Language): SkillCategory[] {
 const aboutContent: Record<Language, AboutApiResponse> = {
   ko: {
     profile: {
-      headline: "성장하는 프론트엔드 개발자\n최민석입니다",
+      headline: "성장하는 풀사이클 개발자\n최민석입니다",
       description:
         "상명대학교 스마트정보통신공학과 전공, 앱&웹 연계전공을 복수 전공하며 이론과 실무를 함께 익혔습니다. 사용자 경험을 최우선으로 생각하며, 비즈니스 목표에 기여하는 웹 서비스를 만듭니다.",
       imageAlt: "최민석 프로필 이미지",
@@ -370,7 +370,7 @@ const aboutContent: Record<Language, AboutApiResponse> = {
   },
   en: {
     profile: {
-      headline: "Growing Frontend Developer\nChoi Min Seok",
+      headline: "Growing FullCycle Developer\nChoi Min Seok",
       description:
         "Double-majoring in Smart Information & Communication Engineering and the App & Web convergence program at Sangmyung University. I build web services that prioritize user experience while supporting business goals.",
       imageAlt: "Profile portrait of Choi Min Seok",

--- a/app/lib/i18n/texts.ts
+++ b/app/lib/i18n/texts.ts
@@ -71,7 +71,7 @@ export function getAboutTexts(
     ko: {
       resume: "[ GET_RESUME ]",
       initLabel: "[INITIATING_CONNECTION...]",
-      roleSuffix: ": FRONTEND_DEV",
+      roleSuffix: ": FULLCYCLE_DEV",
       scrollLabel: "[SCROLL_SEQUENCE]",
       philosophyTitle: "// PHILOSOPHY.LOG",
       philosophyDescription:
@@ -106,7 +106,7 @@ export function getAboutTexts(
     en: {
       resume: "[ GET_RESUME ]",
       initLabel: "[INITIATING_CONNECTION...]",
-      roleSuffix: ": FRONTEND_DEV",
+      roleSuffix: ": FULLCYCLE_DEV",
       scrollLabel: "[SCROLL_SEQUENCE]",
       philosophyTitle: "// PHILOSOPHY.LOG",
       philosophyDescription:
@@ -157,7 +157,7 @@ export function getAboutTexts(
 // Hero 섹션 텍스트
 export const heroTexts: Record<Language, HeroTexts> = {
   ko: {
-    role: "FRONTEND DEVELOPER",
+    role: "FULLCYCLE DEVELOPER",
     tagline: "MINSEOK CHOI",
     glitchText: "데이터_손상",
     glitchMessage: "연결 재설정 중...",
@@ -187,7 +187,7 @@ export const heroTexts: Record<Language, HeroTexts> = {
     },
   },
   en: {
-    role: "FRONTEND DEVELOPER",
+    role: "FULLCYCLE DEVELOPER",
     tagline: "MINSEOK CHOI",
     glitchText: "DATA_CORRUPTED",
     glitchMessage: "Attempting to re-establish connection...",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> - **About capabilities UI**: Render brief summaries from `skillCategories` (title/description) above cores in `AboutCapabilitiesSection`; minor layout/animation intact.
> - **Hero tech/role**: Update `TECH_PILLS` to include `Node.js` and `Flutter`; i18n changes set role/labels to "FULLCYCLE DEVELOPER" and `roleSuffix` to `FULLCYCLE_DEV`.
> - **PDF pages UX**: In `PDFIndexPage` and `ProjectPDFView`, add fixed home/back links; make project cards fully clickable when `slug` exists (wrap in `Link` with focus styles) and keep non-slug entries as static cards; add on-screen print hint.
> - **Copy tweaks**: Update database text to "cloud services" (ko/en) and profile headline to "FullCycle Developer".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cfadb4d6b1fe8316790d003932209e19526d92d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->